### PR TITLE
feat(dockerfile): Addition of dockerfile for building Abstruse image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/*
+dist/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# Stage 1 image
+FROM mhart/alpine-node:8 as base
+
+LABEL maintainer="Jan Kuri <jan@bleenco.com>" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.name="abstruse" \
+      org.label-schema.description="Continuous integration platform, simple, scalable and fast" \
+      org.label-schema.url="https://abstruse.bleenco.io/" \
+      org.label-schema.vcs-url="https://github.com/bleenco/abstruse" \
+      org.label-schema.vendor="Bleenco" \
+      org.label-schema.vcs-ref="n/a" \
+      org.label-schema.version="dev"
+
+ENV DOCKER_VERSION=17.09.0-ce
+
+RUN apk --no-cache add openssl \
+    && wget https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz -O /tmp/docker.tgz \
+    && mkdir /tmp/docker && tar xzf /tmp/docker.tgz -C /tmp \
+    && ln -s /tmp/docker/docker /usr/bin/docker && chmod 755 /usr/bin/docker && rm -rf /tmp/docker.tgz \
+    && apk del openssl
+
+# Stage 2 image
+FROM base as build
+
+WORKDIR /app
+
+COPY package.json package-lock.json tsconfig.json webpack.*.js /app/
+COPY ./src /app/src
+
+RUN apk add --no-cache --virtual .build-dependencies make gcc g++ python curl sqlite git \
+    && npm set progress=false && npm config set depth 0 \
+    && npm i --only=production \
+    && cp -R node_modules prod_node_modules \
+    && npm i && npm run build:prod && ls -lha /usr/lib/node_modules \
+    && apk del .build-dependencies
+
+
+# Stage 3 image
+FROM alpine:3.6
+
+WORKDIR /app
+
+RUN apk --no-cache add tini sqlite git
+
+COPY --from=base /usr/bin/node /usr/bin/
+COPY --from=base /usr/lib/libgcc* /usr/lib/libstdc* /usr/lib/
+COPY --from=base /tmp/docker/docker /usr/bin/docker
+
+COPY --from=build /app/package.json /app/
+COPY --from=build /app/prod_node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/src/files ./src/files
+
+EXPOSE 6500
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD [ "node", "dist/api/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,6 @@
 # Stage 1 image
 FROM mhart/alpine-node:8 as base
 
-LABEL maintainer="Jan Kuri <jan@bleenco.com>" \
-      org.label-schema.schema-version="1.0" \
-      org.label-schema.name="abstruse" \
-      org.label-schema.description="Continuous integration platform, simple, scalable and fast" \
-      org.label-schema.url="https://abstruse.bleenco.io/" \
-      org.label-schema.vcs-url="https://github.com/bleenco/abstruse" \
-      org.label-schema.vendor="Bleenco" \
-      org.label-schema.vcs-ref="n/a" \
-      org.label-schema.version="dev"
-
 ENV DOCKER_VERSION=17.09.0-ce
 
 RUN apk --no-cache add openssl \
@@ -18,6 +8,7 @@ RUN apk --no-cache add openssl \
     && mkdir /tmp/docker && tar xzf /tmp/docker.tgz -C /tmp \
     && ln -s /tmp/docker/docker /usr/bin/docker && chmod 755 /usr/bin/docker && rm -rf /tmp/docker.tgz \
     && apk del openssl
+
 
 # Stage 2 image
 FROM base as build
@@ -37,6 +28,16 @@ RUN apk add --no-cache --virtual .build-dependencies make gcc g++ python curl sq
 
 # Stage 3 image
 FROM alpine:3.6
+
+LABEL maintainer="Jan Kuri <jan@bleenco.com>" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.name="abstruse" \
+      org.label-schema.description="Continuous integration platform, simple, scalable and fast" \
+      org.label-schema.url="https://abstruse.bleenco.io/" \
+      org.label-schema.vcs-url="https://github.com/bleenco/abstruse" \
+      org.label-schema.vendor="Bleenco" \
+      org.label-schema.vcs-ref="n/a" \
+      org.label-schema.version="dev"
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:prod": "npm run build && npm run build:app:prod",
     "build:app": "webpack --env.dev --progress",
     "build:app:prod": "webpack --env.aot --env.prod -p",
+    "build-image": "GIT_REV=$(git rev-parse --short HEAD); docker build -t bleenco/abstruse:${npm_package_version} --label org.label-schema.version=\"${npm_package_version}\" --label org.label-schema.vcs-ref=\"${GIT_REV}\" .",
     "start": "webpack-dev-server --env.dev --env.serve --progress --hot",
     "start:aot": "webpack-dev-server --env.aot --env.dev --env.serve --progress --hot",
     "lint": "tslint ./src/**/*.ts",


### PR DESCRIPTION
Adds a new shiny Dockerfile to allow the builds of the abstruse images. 

I've tried to get it as small as possible and have managed to (I think) shave of about 100MB from the current image size. 

I've also taken the liberty of adding a number of labels using the label-schema.org standards. You'll notice the vcs-ref and version ones are set to non-sensical ones. I expect that when building the image these will be set on the command line to the correct ones i.e. 

```
docker build -t bleenco/abstruse:$(VERSION) \
  --pull \
  --label org.label-schema.vcs-ref="$(GIT_REV)" \
  --label org.label-schema.version="$(VERSION)" .
```