### PR TITLE
fix(terminal): increase default 1000 numbers scrollback in terminal output

### DIFF
--- a/src/app/components/app-terminal/app-terminal.component.ts
+++ b/src/app/components/app-terminal/app-terminal.component.ts
@@ -18,7 +18,8 @@ export class AppTerminalComponent implements OnInit {
     let xterm: any = <any>xterminal;
     xterm.loadAddon('fit');
     this.term = new xterm({
-      cols: 120
+      cols: 120,
+      scrollback: 100000
     });
   }
 


### PR DESCRIPTION
related: https://github.com/bleenco/abstruse/issues/322