### PR TITLE
fix(platform-server): change repository url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="1.5.3"></a>
+## [1.5.3](https://github.com/bleenco/abstruse/compare/v1.5.2...v1.5.3) (2018-04-05)
+
+
+### Bug Fixes
+
+* **platform-server:** change repository url ([1c4160b](https://github.com/bleenco/abstruse/commit/1c4160b)), closes [#350](https://github.com/bleenco/abstruse/issues/350)
+
+
+
 <a name="1.5.2"></a>
 ## [1.5.2](https://github.com/bleenco/abstruse/compare/v1.5.1...v1.5.2) (2018-03-03)
 

--- a/src/api/commit-status.ts
+++ b/src/api/commit-status.ts
@@ -10,7 +10,7 @@ export function sendSuccessStatus(build: any, buildId: number): Promise<void> {
       let sha = build.data.after || build.data.pull_request && build.data.pull_request.head.sha ||
         build.data.sha;
       let name = build.repository.full_name;
-      let gitUrl = `https://api.github.com/repos/${name}/statuses/${sha}`;
+      let gitUrl = `https://${build.repository.api_url || 'api.github.com'}/repos/${name}/statuses/${sha}`;
       let abstruseUrl = `${config.url}/build/${buildId}`;
 
       return setGitHubStatusSuccess(gitUrl, abstruseUrl,


### PR DESCRIPTION
change status endpoint to use the configured `repository.api_url`
change `setSuccessStatus` method to use configured `repository.api_url`

fix #350