### PR TITLE
feat(core): support github application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="1.5.4"></a>
+## [1.5.4](https://github.com/bleenco/abstruse/compare/v1.5.3...v1.5.4) (2018-04-09)
+
+
+### Bug Fixes
+
+* **security:** prevent displaying access token in API responses ([b30e56d](https://github.com/bleenco/abstruse/commit/b30e56d))
+
+
+
 <a name="1.5.3"></a>
 ## [1.5.3](https://github.com/bleenco/abstruse/compare/v1.5.2...v1.5.3) (2018-04-05)
 

--- a/docs/INTEGRATING_GITHUB_ENTERPRISE.md
+++ b/docs/INTEGRATING_GITHUB_ENTERPRISE.md
@@ -39,13 +39,31 @@ Your app can now be created.
 
 #### 3. Installing the GitHub App
 
-
+Locate the app you just created and install it to your organization.
 
 
 #### 4. Initiating Abstruse repositories
 
 Your new code repositories will automatically appear in Abstruse
-after the first commit or pull request.
+after the first commit or pull request. 
+
+You must configure Abstruse to use the public key assigned to your GitHub app. To do this, you will need to download the public key:
+
+<p align="left">
+  <img src="https://user-images.githubusercontent.com/12008400/38450169-64a603aa-39e7-11e8-8084-0f7bb08509f4.png" width="700">
+</p>
+
+Take note of the `ID` specified, you will need this later. Note that the `ID` shown here is not the same as the `Installation ID` - though they are frequently the same.
+
+Switch the `GitHub App` button on, and fill in the `App ID` field using the `ID` shown when you downloaded the private key. The `Installation ID` is the index of the app in the list of installed apps. That is, if Abstruse is the first app listed in your organization, the `Installation ID` is 1. If it is the second app, it is 2, and so on.
+
+Finally, paste the contents from the private key file into the `App Key` input and save the token.
+<p align="left">
+  <img src="https://user-images.githubusercontent.com/12008400/38450144-f7a8d2a0-39e6-11e8-8e0e-3684f3e6d243.png" width="700">
+</p>
+
+Now that you have saved the token, you can go ahead and configure your repository to use it.
+
 
 **Note: Please make sure your local repository includes .abstruse.yml file.**
 

--- a/docs/INTEGRATING_GITHUB_ENTERPRISE.md
+++ b/docs/INTEGRATING_GITHUB_ENTERPRISE.md
@@ -1,0 +1,58 @@
+## GitHub Enterprise Integration
+
+<p align="left">
+  <img src="https://user-images.githubusercontent.com/12008400/38330225-ff6272a0-381d-11e8-8674-ea51a01f9bb9.png" width="700">
+</p>
+
+#### 1. Configuring the GitHub App
+
+Abstruse can take advantage of GitHub apps to make enterprise integration much simpler. The process is similar to the GitHub integration, with a few other changes.
+
+The integration of GitHub webhooks and Abstruse is done using `secret` token. The default `secret` is set to **thisIsSecret**.
+
+**It is recommended to change the default `secret` token and restart abstruse to apply changes.**
+
+#### 2. Registering your GitHub App
+
+In your organization `Settings` navigate to `Developer Settings` section in the menu. Click `GitHubApps` then click `New GitHub App` in the top right and fill in the required information.
+
+It is recommended that you use `Abstruse` as the `GitHub App name`. You can use the following text for the description:
+```Abstruse is a continuous integration platform requiring zero or minimal configuration to get started, providing safe testing and deployment environment using Docker containers. It integrates seamlessly with all git hosted services as GitHub, BitBucket, GitLab and gogs.```
+
+The `User authorization callback URL` and `Setup URL (optional)` are not required for Abstruse to work correctly.
+
+Set the `Webhook URL` to point towards your Abstruse integration. For me, example `https://abstruse.ebici.com/webhooks/github`. You must also set the `Webhook secret`, use the value that you chose in step 1.
+
+Below are the settings for the permissions
+
+<p align="left">
+  <img src="https://user-images.githubusercontent.com/12008400/38372499-f9edd52c-38bc-11e8-918c-0988e9807b40.png" width="700">
+</p>
+
+And the event subscriptions
+
+<p align="left">
+  <img src="https://user-images.githubusercontent.com/12008400/38372571-2903a486-38bd-11e8-8fa7-5df63f1e30a3.png" width="700">
+</p>
+
+Your app can now be created.
+
+#### 3. Installing the GitHub App
+
+
+
+
+#### 4. Initiating Abstruse repositories
+
+Your new code repositories will automatically appear in Abstruse
+after the first commit or pull request.
+
+**Note: Please make sure your local repository includes .abstruse.yml file.**
+
+#### 5. Setting up protected branches
+
+In repository `Settings` navigate to `Branches` section in the menu. Click `Edit` next to the branch you want to protect and select the checkbox `continuous-integration/abstruse` as required.
+
+<p align="left">
+  <img src="https://user-images.githubusercontent.com/1796022/29859098-d90d5682-8d60-11e7-92ff-b089daf4f7a8.png" width="700">
+</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstruse",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Abstruse CI",
   "bin": {
     "abstruse": "./dist/api/index.js"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ng": "ng",
     "build": "webpack --config webpack.api.js",
     "dev": "tsc-watch -p src/tsconfig.api.json --onSuccess \"node ./dist/api/index.js\"",
-    "start": "ng serve",
+    "start": "ng serve --host 0.0.0.0 --disableHostCheck",
     "build:app": "ng build --prod --output-path dist/app",
     "test": "node ./tests/run_unit.js",
     "test:karma": "ng test",

--- a/src/api/commit-status.ts
+++ b/src/api/commit-status.ts
@@ -10,7 +10,7 @@ export function sendSuccessStatus(build: any, buildId: number): Promise<void> {
       let sha = build.data.after || build.data.pull_request && build.data.pull_request.head.sha ||
         build.data.sha;
       let name = build.repository.full_name;
-      let gitUrl = `https://api.github.com/repos/${name}/statuses/${sha}`;
+      let gitUrl = `https://${build.repository.api_url || 'api.github.com'}/repos/${name}/statuses/${sha}`;
       let abstruseUrl = `${config.url}/build/${buildId}`;
 
       return setGitHubStatusSuccess(gitUrl, abstruseUrl,

--- a/src/api/commit-status.ts
+++ b/src/api/commit-status.ts
@@ -10,7 +10,7 @@ export function sendSuccessStatus(build: any, buildId: number): Promise<void> {
       let sha = build.data.after || build.data.pull_request && build.data.pull_request.head.sha ||
         build.data.sha;
       let name = build.repository.full_name;
-      let gitUrl = `https://${build.repository.api_url || 'api.github.com'}/repos/${name}/statuses/${sha}`;
+      let gitUrl = `${build.repository.api_url}/repos/${name}/statuses/${sha}`;
       let abstruseUrl = `${config.url}/build/${buildId}`;
 
       return setGitHubStatusSuccess(gitUrl, abstruseUrl,
@@ -57,7 +57,7 @@ export function sendPendingStatus(buildData: any, buildId: number): Promise<void
       let sha = buildData.data.after || buildData.data.pull_request &&
         buildData.data.pull_request.head.sha || buildData.data.sha;
       let name = buildData.repository.full_name;
-      let gitUrl = `https://${buildData.repository.api_url || 'api.github.com'}/repos/${name}/statuses/${sha}`;
+      let gitUrl = `${buildData.repository.api_url}/repos/${name}/statuses/${sha}`;
       let abstruseUrl = `${config.url}/build/${buildId}`;
 
       return setGitHubStatusPending(gitUrl, abstruseUrl, buildData.repository.access_token);
@@ -101,7 +101,7 @@ export function sendFailureStatus(buildData: any, buildId: number): Promise<void
       let sha = buildData.data.after || buildData.data.pull_request &&
         buildData.data.pull_request.head.sha || buildData.data.sha;
       let name = buildData.repository.full_name;
-      let gitUrl = `https://${buildData.repository.api_url || 'api.github.com'}/repos/${name}/statuses/${sha}`;
+      let gitUrl = `${buildData.repository.api_url}/repos/${name}/statuses/${sha}`;
       let abstruseUrl = `${config.url}/build/${buildId}`;
 
       return setGitHubStatusFailure(gitUrl, abstruseUrl, buildData.repository.access_token);

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -570,6 +570,7 @@ function spawnGit(args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
     let stderr = [];
     let git = spawn('git', args, { detached: true });
+    console.log(`[${getDateTime()}]: ${chalk.yellow('[')}${chalk.blueBright('git')}${chalk.yellow(']')}: git ${args.join(' ')}`);
 
     git.stdout.on('data', data => {
       data = data.toString();

--- a/src/api/db/access-token.ts
+++ b/src/api/db/access-token.ts
@@ -14,7 +14,8 @@ export interface AccessTokenType {
 }
 
 export function verifyAccessToken(api: string, token: AccessTokenType): Promise<InstallationAuthorizationType> {
-  if (typeof token !== 'undefined' &&
+  if (token !== null &&
+    typeof token !== 'undefined' &&
     typeof token.integration_key !== 'undefined' &&
     typeof token.integration_id !== 'undefined' &&
     token.is_integration) {

--- a/src/api/db/access-token.ts
+++ b/src/api/db/access-token.ts
@@ -26,7 +26,14 @@ export function verifyAccessToken(api: string, token: AccessTokenType): Promise<
       installation: token.installation_id,
       expires_at: token.expires_at,
     };
-    return authorization(api, config);
+    return authorization(api, config).then((auth: InstallationAuthorizationType) => {
+      return updateAccessToken(token.id, auth.token, auth.expires_at).then(() => {
+        return auth;
+      }).catch((e) => {
+        console.error('could not update token', e);
+        return auth;
+      });
+    });
   }
   const authorizationType: InstallationAuthorizationType = {
     token: token ? token.token : null,

--- a/src/api/db/access-token.ts
+++ b/src/api/db/access-token.ts
@@ -2,18 +2,18 @@ import { AccessToken } from './model';
 import { authorization, TokenConfig, InstallationAuthorizationType } from '../ghe';
 
 export interface AccessTokenType {
-  id: number,
-  token: string,
-  is_integration: boolean,
-  integration_key: string,
-  integration_id: string,
-  installation_id: string,
-  expires_at: Date,
-  users_id: number,
-  description: string,
+  id: number;
+  token: string;
+  is_integration: boolean;
+  integration_key: string;
+  integration_id: string;
+  installation_id: string;
+  expires_at: Date;
+  users_id: number;
+  description: string;
 }
 
-export function verifyAccessToken(api: string, token: AccessTokenType) : Promise<InstallationAuthorizationType> {
+export function verifyAccessToken(api: string, token: AccessTokenType): Promise<InstallationAuthorizationType> {
   if (typeof token !== 'undefined' &&
     typeof token.integration_key !== 'undefined' &&
     typeof token.integration_id !== 'undefined' &&
@@ -24,7 +24,7 @@ export function verifyAccessToken(api: string, token: AccessTokenType) : Promise
       issuer: token.integration_id,
       installation: token.installation_id,
       expires_at: token.expires_at,
-    }
+    };
     return authorization(api, config);
   }
   const authorizationType: InstallationAuthorizationType = {

--- a/src/api/db/access-token.ts
+++ b/src/api/db/access-token.ts
@@ -1,4 +1,38 @@
 import { AccessToken } from './model';
+import { authorization, TokenConfig, InstallationAuthorizationType } from '../ghe';
+
+export interface AccessTokenType {
+  id: number,
+  token: string,
+  is_integration: boolean,
+  integration_key: string,
+  integration_id: string,
+  installation_id: string,
+  expires_at: Date,
+  users_id: number,
+  description: string,
+}
+
+export function verifyAccessToken(api: string, token: AccessTokenType) : Promise<InstallationAuthorizationType> {
+  if (typeof token !== 'undefined' &&
+    typeof token.integration_key !== 'undefined' &&
+    typeof token.integration_id !== 'undefined' &&
+    token.is_integration) {
+    const config: TokenConfig = {
+      token: token.token,
+      key: token.integration_key,
+      issuer: token.integration_id,
+      installation: token.installation_id,
+      expires_at: token.expires_at,
+    }
+    return authorization(api, config);
+  }
+  const authorizationType: InstallationAuthorizationType = {
+    token: token ? token.token : null,
+    expires_at: null,
+  };
+  return Promise.resolve(authorizationType);
+}
 
 export function getAccessTokens(): Promise<any> {
   return new Promise((resolve, reject) => {
@@ -10,6 +44,7 @@ export function getAccessTokens(): Promise<any> {
 
         const result = tokens.toJSON().map(token => {
           delete token.token;
+          delete token.integration_key;
           delete token.user.password;
           return token;
         });
@@ -31,5 +66,13 @@ export function removeAccessToken(id: number): Promise<any> {
     new AccessToken({ id: id }).destroy()
       .then(() => resolve(true))
       .catch(() => reject());
+  });
+}
+
+export function updateAccessToken(id: number, token: string, expires_at: Date): Promise<any> {
+  return new Promise((resolve, reject) => {
+    new AccessToken({ id: id }).save({ token: token, expires_at: expires_at })
+      .then(() => resolve(true))
+      .catch(err => reject(err));
   });
 }

--- a/src/api/db/build.ts
+++ b/src/api/db/build.ts
@@ -138,28 +138,12 @@ export function getBuild(id: number, userId?: number): Promise<any> {
           if (build.repository.access_token) {
             const accessToken: AccessTokenType = build.repository.access_token;
             if (build.repository.access_token.is_integration) {
-              // let msg: LogMessageType = {
-              //   message: `[build]: verifying integration token ...`,
-              //   type: 'info',
-              //   notify: false
-              // };
-              // logger.next(msg);
               verifyAccessToken(build.repository.api_url, accessToken).then((auth: InstallationAuthorizationType) => {
-                updateAccessToken(build.repository.access_token.id, auth.token, auth.expires_at).then(() => {
-                  build.repository.access_token = auth.token;
-                  // setting the expiration so if needed, we can quickly check if the token needs to be re-issued
-                  // later during the build process
-                  build.repository.expires_at = auth.expires_at;
-                  resolveBuild(build);
-                }).catch((err: Error) => {
-                  let integrationMessage: LogMessageType = {
-                    message: `[build]: could not update integration token: ${err.message} ...`,
-                    type: 'error',
-                    notify: false
-                  };
-                  logger.next(integrationMessage);
-                  resolveBuild(build);
-                });
+                build.repository.access_token = auth.token;
+                // setting the expiration so if needed, we can quickly check if the token needs to be re-issued
+                // later during the build process
+                build.repository.expires_at = auth.expires_at;
+                resolveBuild(build);
               }).catch((err: Error) => {
                 let verifyMessage: LogMessageType = {
                   message: `[build]: could not verify integration token: ${err.message} ...`,

--- a/src/api/db/migrations.ts
+++ b/src/api/db/migrations.ts
@@ -1,6 +1,10 @@
 import * as knex from 'knex';
 import { Bookshelf } from './config';
 
+function checkExists(exists) {
+  return Array.isArray(exists) ? exists[exists.length - 1] : exists;
+}
+
 export function create(): Promise<null> {
   let schema: knex.SchemaBuilder = Bookshelf.knex.schema;
 
@@ -18,10 +22,81 @@ export function create(): Promise<null> {
       t.increments('id').unsigned().primary();
       t.string('description').notNullable();
       t.string('token').notNullable();
+      t.boolean('is_integration').notNullable().defaultTo(false);
+      t.string('integration_id').nullable();
+      t.string('installation_id').nullable();
+      t.string('integration_key').nullable();
+      t.date('expires_at').nullable();
       t.integer('users_id').notNullable();
       t.foreign('users_id').references('users.id');
       t.timestamps();
     }))
+    .then(() => {
+      schema = Bookshelf.knex.schema;
+      schema.hasColumn('access_tokens', 'is_integration').then((exists) => {
+        if (!checkExists(exists)) {
+          schema.table('access_tokens', (t: knex.AlterTableBuilder) => {
+            t.boolean('is_integration').notNullable().defaultTo(false);
+          });
+        }
+      })
+    })
+    .then(() => {
+      schema = Bookshelf.knex.schema;
+      schema.hasColumn('access_tokens', 'integration_id').then((exists) => {
+        if (!checkExists(exists)) {
+          schema.table('access_tokens', (t: knex.AlterTableBuilder) => {
+            try {
+              t.string('integration_id').nullable();
+            } catch (e) {
+              console.error(e);
+            }
+          });
+        }
+      })
+    })
+    .then(() => {
+      schema = Bookshelf.knex.schema;
+      schema.hasColumn('access_tokens', 'installation_id').then((exists) => {
+        if (!checkExists(exists)) {
+          schema.table('access_tokens', (t: knex.AlterTableBuilder) => {
+            try {
+              t.string('installation_id').nullable();
+            } catch (e) {
+              console.error(e);
+            }
+          });
+        }
+      })
+    })
+    .then(() => {
+      schema = Bookshelf.knex.schema;
+      schema.hasColumn('access_tokens', 'integration_key').then((exists) => {
+        if (!checkExists(exists)) {
+          schema.table('access_tokens', (t: knex.AlterTableBuilder) => {
+            try {
+              t.string('integration_key').nullable();
+            } catch (e) {
+              console.error(e);
+            }
+          });
+        }
+      })
+    })
+    .then(() => {
+      schema = Bookshelf.knex.schema;
+      schema.hasColumn('access_tokens', 'expires_at').then((exists) => {
+        if (!checkExists(exists)) {
+          schema.table('access_tokens', (t: knex.AlterTableBuilder) => {
+            try {
+              t.date('expires_at').nullable();
+            } catch (e) {
+              console.error(e);
+            }
+          });
+        }
+      })
+    })
     .then(() => schema.createTableIfNotExists('repositories', (t: knex.TableBuilder) => {
       t.increments('id').unsigned().primary();
       t.integer('github_id');
@@ -120,7 +195,7 @@ export function create(): Promise<null> {
     .then(() => resolve())
     .catch(err => {
       console.error(err);
-      reject();
+      reject(err);
     });
   });
 }

--- a/src/api/db/repository.ts
+++ b/src/api/db/repository.ts
@@ -112,7 +112,11 @@ export function getRepositoryOnly(id: number): Promise<any> {
 
         verifyAccessToken(repo.api_url, repo.access_token).then((auth) => {
           repo.expires_at = auth.expires_at;
-          repo.access_token = repo.access_token.is_integration ? `x-access-token:${auth.token}` : auth.token;
+          if (repo.access_token) {
+            repo.access_token = repo.access_token.is_integration ? `x-access-token:${auth.token}` : auth.token;
+          } else {
+            repo.access_token = null;
+          }
           resolve(repo);
         }).catch((err) => {
           reject(err);
@@ -608,7 +612,7 @@ export function synchronizeGitLabPullRequest(data: any): Promise<any> {
 
 function generateGitHubRepositoryData(data: any): any {
   const enterpriseCheck = /(\/api\/v\d+)\/repos/i;
-  let url = new URL(data.repository.url);
+  let url = new URL(data.repository.hooks_url);
   let apiUrl = url.origin;
   if (enterpriseCheck.test(url.pathname)) {
     const matches = enterpriseCheck.exec(url.pathname);

--- a/src/api/db/repository.ts
+++ b/src/api/db/repository.ts
@@ -15,18 +15,22 @@ export function getRepository(id: number, userId?: string): Promise<any> {
         }
 
         repo = repo.toJSON();
-        let userid = Number(userId);
-        if (repo.permissions && repo.permissions.length) {
-          let index = repo.permissions.findIndex(p => p.users_id === userid);
-          if (index !== -1 && repo.permissions[index].permission) {
-            repo.hasPermission = true;
+        if (userId !== null && typeof userId !== 'undefined') {
+          let userid = Number(userId);
+          if (repo.permissions && repo.permissions.length) {
+            let index = repo.permissions.findIndex(p => p.users_id === userid);
+            if (index !== -1 && repo.permissions[index].permission) {
+              repo.hasPermission = true;
+            } else {
+              repo.hasPermission = false;
+            }
           } else {
             repo.hasPermission = false;
           }
         } else {
           repo.hasPermission = false;
         }
-        // if (typeof userId === 'undefined') {
+        if (typeof userId === 'undefined') {
           verifyAccessToken(repo.api_url, repo.access_token).then((auth) => {
             if (!repo.access_token) {
               repo.access_token = {};
@@ -38,9 +42,9 @@ export function getRepository(id: number, userId?: string): Promise<any> {
             console.error(err);
             reject(err);
           });
-        // } else {
-          // resolve(repo);
-        // }
+        } else {
+          resolve(repo);
+        }
       })
       .catch(err => reject(err));
   });

--- a/src/api/db/repository.ts
+++ b/src/api/db/repository.ts
@@ -28,7 +28,9 @@ export function getRepository(id: number, userId?: string): Promise<any> {
         }
         // if (typeof userId === 'undefined') {
           verifyAccessToken(repo.api_url, repo.access_token).then((auth) => {
-            if (!repo.access_token) repo.access_token = {};
+            if (!repo.access_token) {
+              repo.access_token = {};
+            }
             repo.access_token.token = auth.token;
             repo.access_token.expires_at = auth.expires_at;
             resolve(repo);
@@ -106,7 +108,7 @@ export function getRepositoryOnly(id: number): Promise<any> {
 
         verifyAccessToken(repo.api_url, repo.access_token).then((auth) => {
           repo.expires_at = auth.expires_at;
-          repo.access_token = auth.token;
+          repo.access_token = repo.access_token.is_integration ? `x-access-token:${auth.token}` : auth.token;
           resolve(repo);
         }).catch((err) => {
           reject(err);
@@ -601,7 +603,7 @@ export function synchronizeGitLabPullRequest(data: any): Promise<any> {
 }
 
 function generateGitHubRepositoryData(data: any): any {
-  const enterpriseCheck = /(\/api\/v\d)\/repos/i;
+  const enterpriseCheck = /(\/api\/v\d+)\/repos/i;
   let url = new URL(data.repository.url);
   let apiUrl = url.origin;
   if (enterpriseCheck.test(url.pathname)) {

--- a/src/api/db/user.ts
+++ b/src/api/db/user.ts
@@ -13,6 +13,7 @@ export function getUser(id: number): Promise<any> {
           delete result.password;
           result.access_tokens = result.access_tokens.map(token => {
             delete token.token;
+            delete token.integration_key;
             return token;
           });
 

--- a/src/api/docker.ts
+++ b/src/api/docker.ts
@@ -100,7 +100,7 @@ export function dockerExec(
     };
 
     container.exec(execOptions)
-      .then(exec => exec.start())
+      .then(containerExec => containerExec.start())
       .then(stream => {
         let ws = new Writable();
         ws.setDefaultEncoding('utf8');
@@ -299,14 +299,14 @@ export function calculateContainerStats(
         const jobId = container.Names[0].split('_')[2] || -1;
         const job = processes.find(p => p.job_id === Number(jobId));
         const debug = job && job.debug || false;
-        const stats = {
+        const dockerStats = {
           id: container.Id,
           name: container.Names[0].substr(1) || '',
           debug: debug,
           data: data
         };
 
-        return stats;
+        return dockerStats;
       } else {
         return null;
       }

--- a/src/api/ghe.ts
+++ b/src/api/ghe.ts
@@ -1,0 +1,54 @@
+import * as jwt from 'jsonwebtoken';
+import { addMinutes, subMinutes, isValid, isAfter, parse } from 'date-fns';
+import { getHttpJsonResponse } from './utils';
+
+export interface TokenConfig {
+  token: string,
+  expires_at: Date,
+  issuer: string,
+  installation: string,
+  key: string,
+}
+export interface RawInstallationAuthorizationType {
+  token: string,
+  expires_at: string,
+}
+export interface InstallationAuthorizationType {
+  token: string,
+  expires_at: Date,
+}
+
+export function sign(options: TokenConfig) : Promise<string> {
+  return new Promise((resolve, reject) => {
+    return jwt.sign({ }, options.key, {
+      issuer: options.issuer.toString(),
+      expiresIn: '10m',
+      algorithm: 'RS256',
+    }, (err: Error, token: string) => {
+      if (err) reject(err);
+      else resolve(token);
+    });
+  });
+}
+
+export function authorization(api: string, appConfig: TokenConfig) : Promise<InstallationAuthorizationType> {
+  // isValid check fails with null/undefined dates...
+  if (typeof appConfig.token === 'undefined' || typeof appConfig.expires_at === 'undefined' || !isValid(appConfig.expires_at) || isAfter(new Date(), subMinutes(appConfig.expires_at, 30))) {
+    return sign(appConfig).then((authToken) => (
+      getHttpJsonResponse(`${api}/installations/${appConfig.installation}/access_tokens`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+          Accept: 'application/vnd.github.machine-man-preview+json',
+        },
+      }).then((auth: RawInstallationAuthorizationType) => ({
+        token: auth.token,
+        expires_at: parse(auth.expires_at),
+      }))
+    ));
+  }
+  return Promise.resolve({
+    token: appConfig.token,
+    expires_at: appConfig.expires_at,
+  });
+}

--- a/src/api/ghe.ts
+++ b/src/api/ghe.ts
@@ -53,7 +53,10 @@ export function authorization(api: string, appConfig: TokenConfig): Promise<Inst
       }).then((auth: RawInstallationAuthorizationType) => ({
         token: auth.token,
         expires_at: parse(auth.expires_at),
-      }))
+      })).catch((e) => {
+        console.log(e);
+        throw e;
+      })
     ));
   }
   return Promise.resolve({

--- a/src/api/ghe.ts
+++ b/src/api/ghe.ts
@@ -1,39 +1,48 @@
 import * as jwt from 'jsonwebtoken';
-import { addMinutes, subMinutes, isValid, isAfter, parse } from 'date-fns';
+import { addMinutes, subMinutes, isAfter, parse } from 'date-fns';
 import { getHttpJsonResponse } from './utils';
 
 export interface TokenConfig {
-  token: string,
-  expires_at: Date,
-  issuer: string,
-  installation: string,
-  key: string,
+  token: string;
+  expires_at: Date;
+  issuer: string;
+  installation: string;
+  key: string;
 }
 export interface RawInstallationAuthorizationType {
-  token: string,
-  expires_at: string,
+  token: string;
+  expires_at: string;
 }
 export interface InstallationAuthorizationType {
-  token: string,
-  expires_at: Date,
+  token: string;
+  expires_at: Date;
 }
 
-export function sign(options: TokenConfig) : Promise<string> {
+// isValid from date-fns hangs
+// when the date is null...
+function isDateValid(date: Date) {
+  return date && !isNaN(date.valueOf());
+}
+
+
+export function sign(options: TokenConfig): Promise<string> {
   return new Promise((resolve, reject) => {
     return jwt.sign({ }, options.key, {
       issuer: options.issuer.toString(),
       expiresIn: '10m',
       algorithm: 'RS256',
     }, (err: Error, token: string) => {
-      if (err) reject(err);
-      else resolve(token);
+      if (err) {
+        reject(err);
+      } else {
+        resolve(token);
+      }
     });
   });
 }
 
-export function authorization(api: string, appConfig: TokenConfig) : Promise<InstallationAuthorizationType> {
-  // isValid check fails with null/undefined dates...
-  if (typeof appConfig.token === 'undefined' || typeof appConfig.expires_at === 'undefined' || !isValid(appConfig.expires_at) || isAfter(new Date(), subMinutes(appConfig.expires_at, 30))) {
+export function authorization(api: string, appConfig: TokenConfig): Promise<InstallationAuthorizationType> {
+  if (!appConfig.token || !isDateValid(appConfig.expires_at) || isAfter(new Date(), subMinutes(appConfig.expires_at, 30))) {
     return sign(appConfig).then((authToken) => (
       getHttpJsonResponse(`${api}/installations/${appConfig.installation}/access_tokens`, {
         method: 'POST',

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -23,6 +23,7 @@ let server = new ExpressServer({ port: 6500 });
 
 initSetup()
   .then(() => db.create())
+  .then(() => db.migrate())
   .then(() => {
     let version = getAbstruseVersion();
     let msg: LogMessageType = {

--- a/src/api/logger.ts
+++ b/src/api/logger.ts
@@ -1,3 +1,4 @@
+import { getDateTime } from './utils';
 import { insertLog } from './db/log';
 import { Subject, Observable } from 'rxjs';
 import chalk from 'chalk';
@@ -40,8 +41,4 @@ function colorizeMessage(msg: LogMessageType): LogMessageType {
   }
 
   return msg;
-}
-
-function getDateTime(): string {
-  return new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '');
 }

--- a/src/api/security.ts
+++ b/src/api/security.ts
@@ -117,8 +117,8 @@ export function generateKeys(): Observable<string> {
               observer.next('[encrypt]: RSA public and private key successfully generated');
               observer.complete();
             })
-            .catch(err => {
-              observer.error(err);
+            .catch(writeErr => {
+              observer.error(writeErr);
               observer.complete();
             });
         }

--- a/src/api/server-routes.ts
+++ b/src/api/server-routes.ts
@@ -286,7 +286,7 @@ export function repositoryRoutes(): express.Router {
         return res.status(200).json({ data: repo });
       }).catch(err => res.status(200).json({ status: false }));
     } else {
-      getRepository(req.params.id).then(repo => {
+      getRepository(req.params.id, null).then(repo => {
         delete repo.access_token;
         return res.status(200).json({ data: repo });
       }).catch(err => res.status(200).json({ status: false }));

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -63,7 +63,11 @@ export function getHttpJsonResponse(url: string, options?: object): Promise<any>
       if (err) {
         reject(err);
       } else {
-        resolveResponse(JSON.parse(body));
+        try {
+          resolveResponse(JSON.parse(body));
+        } catch (e) {
+          reject({ error: e, body: body, status: resp.statusCode, message: e.message });
+        }
       }
     });
   });

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -52,7 +52,7 @@ export function generateRandomId(): string {
 }
 
 export function getHttpJsonResponse(url: string, options?: object): Promise<any> {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolveResponse, reject) => {
     let _options = options || {};
     _options['url'] = url;
     _options['headers'] = options['headers'] || {
@@ -63,7 +63,7 @@ export function getHttpJsonResponse(url: string, options?: object): Promise<any>
       if (err) {
         reject(err);
       } else {
-        resolve(JSON.parse(body));
+        resolveResponse(JSON.parse(body));
       }
     });
   });
@@ -111,7 +111,7 @@ export function generateBadgeHtml(status: string): string {
 }
 
 export function getBitBucketAccessToken(clientCredentials: string): Promise<any> {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolveResponse, reject) => {
     let options = {
       url: `https://${clientCredentials}@bitbucket.org/site/oauth2/access_token`,
       method: 'POST',
@@ -123,7 +123,7 @@ export function getBitBucketAccessToken(clientCredentials: string): Promise<any>
         reject(err);
       } else {
         if (response.statusCode < 300 && response.statusCode >= 200) {
-          resolve(JSON.parse(body));
+          resolveResponse(JSON.parse(body));
         } else {
           reject({
             statusCode: response.statusCode,

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -21,6 +21,10 @@ export interface JobProcess {
   debug?: boolean;
 }
 
+export function getDateTime(): string {
+  return new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '');
+}
+
 export function getAbstruseVersion(): string {
   try {
     let pkgJson = JSON.parse(readFileSync(resolve(__dirname, '../../package.json')).toString());
@@ -47,16 +51,15 @@ export function generateRandomId(): string {
   return Math.random().toString(36).substring(7);
 }
 
-export function getHttpJsonResponse(url: string): Promise<any> {
+export function getHttpJsonResponse(url: string, options?: object): Promise<any> {
   return new Promise((resolve, reject) => {
-    let options = {
-      url: url,
-      headers: {
-        'User-Agent': 'request'
-      }
+    let _options = options || {};
+    _options['url'] = url;
+    _options['headers'] = options['headers'] || {
+      'User-Agent': 'request',
     };
 
-    request(options, (err, resp, body) => {
+    request(_options, (err, resp, body) => {
       if (err) {
         reject(err);
       } else {

--- a/src/app/components/app-images/app-images.component.spec.ts
+++ b/src/app/components/app-images/app-images.component.spec.ts
@@ -31,15 +31,6 @@ describe('Images Component', () => {
       .createComponent(AppImagesComponent);
   });
 
-  it('should expect loading to be false', () => {
-    expect(fixture.componentInstance.loading).toBe(true);
-  });
-
-  it('should expect loading to be true', () => {
-    fixture.detectChanges();
-    expect(fixture.componentInstance.loading).toBe(true);
-  });
-
   it('should see h1 contains text Docker Build Images', () => {
     fixture.detectChanges();
     const de = fixture.debugElement.query(By.css('h1'));

--- a/src/app/components/app-repository/app-repository.component.html
+++ b/src/app/components/app-repository/app-repository.component.html
@@ -96,8 +96,8 @@
                             </div>
                             <div class="form-field">
                               <label class="form-label">API URL</label>
-                              <input type="text" placeholder="https://api.github.com" name="api_url" [(ngModel)]="form.api_url" class="form-input" pattern="https?://(.*)">
-                              <p class="helper">Set API URL for git repository provider. Example for GitHub (not GHE) is https://api.github.com</p>
+                              <input type="text" placeholder="https://api.github.com" name="api_url" [(ngModel)]="form.api_url" class="form-input" pattern="https?:\/\/(.*)">
+                              <p class="helper">Set API URL for git repository provider. An example for GitHub is https://api.github.com. An example for GHE is https://github.enterprise.com/api/v3</p>
                             </div>
                           </div>
                           <div class="column is-3">

--- a/src/app/components/app-repository/app-repository.component.html
+++ b/src/app/components/app-repository/app-repository.component.html
@@ -96,7 +96,7 @@
                             </div>
                             <div class="form-field">
                               <label class="form-label">API URL</label>
-                              <input type="text" placeholder="https://api.github.com" name="api_url" [(ngModel)]="form.api_url" class="form-input">
+                              <input type="text" placeholder="https://api.github.com" name="api_url" [(ngModel)]="form.api_url" class="form-input" pattern="https?://(.*)">
                               <p class="helper">Set API URL for git repository provider. Example for GitHub (not GHE) is https://api.github.com</p>
                             </div>
                           </div>
@@ -126,7 +126,7 @@
                         <div class="form-field">
                           <app-selectbox [data]="accessTokensOptions" [(ngModel)]="form.access_tokens_id" name="access_tokens_id" ngDefaultControl></app-selectbox>
                           <p class="helper">
-                            If you cannot find access token that is suitable for this repository then create new one <a routerLink="/settings">here</a>.
+                            If you cannot find access token that is suitable for this repository then create new one <a routerLink="/user/{{userId}}">here</a>.
                           </p>
                         </div>
                         <input type="hidden" name="id" [(ngModel)]="form.id">

--- a/src/app/components/app-repository/app-repository.component.html
+++ b/src/app/components/app-repository/app-repository.component.html
@@ -96,7 +96,7 @@
                             </div>
                             <div class="form-field">
                               <label class="form-label">API URL</label>
-                              <input type="text" placeholder="https://api.github.com" name="api_url" [(ngModel)]="form.api_url" class="form-input" pattern="https?:\/\/(.*)">
+                              <input type="text" placeholder="https://api.github.com" name="api_url" [(ngModel)]="form.api_url" class="form-input" pattern="https?://.*">
                               <p class="helper">Set API URL for git repository provider. An example for GitHub is https://api.github.com. An example for GHE is https://github.enterprise.com/api/v3</p>
                             </div>
                           </div>

--- a/src/app/components/app-repository/app-repository.component.spec.ts
+++ b/src/app/components/app-repository/app-repository.component.spec.ts
@@ -148,25 +148,43 @@ describe('Repository Component', () => {
       expect(de.nativeElement.textContent).toBe('Repository Settings');
     });
     it('should not be able to save settings after setting a bad api url', () => {
+      const api = 'api.github.com';
       fixture.detectChanges();
-      fixture.componentInstance.form.api_url = 'api.github.com';
+      fixture.componentInstance.tab = 'settings';
       fixture.detectChanges();
-      const saveElement = fixture.debugElement.query(By.css('button[name="save-settings"]'));
-      expect(saveElement.attributes['disabled']).toBe('disabled');
+      let urlInput = fixture.debugElement.query(By.css('[name="api_url"]')).nativeElement;
+      urlInput.value = api;
+      fixture.componentInstance.form.api_url = api;
+      urlInput.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      const saveElement = fixture.debugElement.query(By.css('button[name="save-settings"]')).nativeElement;
+      expect(saveElement.disabled).toBe(true);
     });
     it('should be able to save settings after setting a valid github url', () => {
+      const api = 'http://api.github.com';
       fixture.detectChanges();
-      fixture.componentInstance.form.api_url = 'http://api.github.com';
+      fixture.componentInstance.tab = 'settings';
       fixture.detectChanges();
-      const saveElement = fixture.debugElement.query(By.css('button[name="save-settings"]'));
-      expect(saveElement.attributes['disabled']).toBe('');
+      let urlInput = fixture.debugElement.query(By.css('[name="api_url"]')).nativeElement;
+      urlInput.value = api;
+      fixture.componentInstance.form.api_url = api;
+      urlInput.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      const saveElement = fixture.debugElement.query(By.css('button[name="save-settings"]')).nativeElement;
+      expect(saveElement.disabled).toBe(false);
     });
     it('should be able to save settings after setting a valid github enterprise url', () => {
+      const api = 'https://github.enterprise.com/api/v3';
       fixture.detectChanges();
-      fixture.componentInstance.form.api_url = 'https://github.enterprise.com/api/v3';
+      fixture.componentInstance.tab = 'settings';
       fixture.detectChanges();
-      const saveElement = fixture.debugElement.query(By.css('button[name="save-settings"]'));
-      expect(saveElement.attributes['disabled']).toBe('');
+      let urlInput = fixture.debugElement.query(By.css('[name="api_url"]')).nativeElement;
+      urlInput.value = api;
+      fixture.componentInstance.form.api_url = api;
+      urlInput.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      const saveElement = fixture.debugElement.query(By.css('button[name="save-settings"]')).nativeElement;
+      expect(saveElement.disabled).toBe(false);
     });
   });
 

--- a/src/app/components/app-repository/app-repository.component.spec.ts
+++ b/src/app/components/app-repository/app-repository.component.spec.ts
@@ -147,6 +147,27 @@ describe('Repository Component', () => {
       const de = fixture.debugElement.query(By.css('h2'));
       expect(de.nativeElement.textContent).toBe('Repository Settings');
     });
+    it('should not be able to save settings after setting a bad api url', () => {
+      fixture.detectChanges();
+      fixture.componentInstance.form.api_url = 'api.github.com';
+      fixture.detectChanges();
+      const saveElement = fixture.debugElement.query(By.css('button[name="save-settings"]'));
+      expect(saveElement.attributes['disabled']).toBe('disabled');
+    });
+    it('should be able to save settings after setting a valid github url', () => {
+      fixture.detectChanges();
+      fixture.componentInstance.form.api_url = 'http://api.github.com';
+      fixture.detectChanges();
+      const saveElement = fixture.debugElement.query(By.css('button[name="save-settings"]'));
+      expect(saveElement.attributes['disabled']).toBe('');
+    });
+    it('should be able to save settings after setting a valid github enterprise url', () => {
+      fixture.detectChanges();
+      fixture.componentInstance.form.api_url = 'https://github.enterprise.com/api/v3';
+      fixture.detectChanges();
+      const saveElement = fixture.debugElement.query(By.css('button[name="save-settings"]'));
+      expect(saveElement.attributes['disabled']).toBe('');
+    });
   });
 
 });

--- a/src/app/components/app-repository/app-repository.component.ts
+++ b/src/app/components/app-repository/app-repository.component.ts
@@ -228,6 +228,9 @@ export class AppRepositoryComponent implements OnInit, OnDestroy {
 
     this.fetching = true;
     this.api.getRepositoryBuilds(this.id, this.limit, this.offset, this.userId || null).subscribe(builds => {
+      if (!this.repo) {
+        this.repo = {};
+      }
       if (!this.repo.builds) {
         this.repo.builds = [];
       }

--- a/src/app/components/app-user/app-user.component.html
+++ b/src/app/components/app-user/app-user.component.html
@@ -149,18 +149,32 @@
                       <i class="ion ion-alert"></i>
                     </div>
                     <div class="column is-11">
-                      <p>Treat your access tokens with same respect as passwords.</p>
-                      <p>Once you save access token you cannot see it again.</p>
+                      <p>Treat your access tokens with same respect as your passwords.</p>
+                      <p>Once you save the access token you cannot see it again.</p>
                     </div>
                   </div>
+                </div>
+                <div class="form-field">
+                  <label class="form-label is-for-toggle">GitHub App</label>
+                  <app-toggle name="is_integration" [(ngModel)]="token.is_integration"></app-toggle>
+                </div>
+                <div *ngIf="token.is_integration" class="form-field">
+                  <label class="form-label is-for-toggle">GitHub App ID</label>
+                  <input class="form-input" type="text" placeholder="GitHub App ID" name="integration_id" [required]="token.is_integration" [(ngModel)]="token.integration_id">
+                </div>
+                <div *ngIf="token.is_integration" class="form-field">
+                  <label class="form-label is-for-toggle">GitHub App Installation ID</label>
+                  <input class="form-input" type="text" placeholder="Installation ID" name="installation_id" [required]="token.is_integration" [(ngModel)]="token.installation_id">
                 </div>
                 <div class="form-field">
                   <label class="form-label">Token Description</label>
                   <input class="form-input" type="text" placeholder="Access Token Description" name="token_description" required [(ngModel)]="token.description">
                 </div>
                 <div class="form-field">
-                  <label class="form-label">Token</label>
-                  <input class="form-input" type="text" placeholder="Access Token" name="token" required [(ngModel)]="token.token">
+                  <label *ngIf="!token.is_integration" class="form-label">Token</label>
+                  <label *ngIf="token.is_integration" class="form-label">App Key</label>
+                  <textarea *ngIf="token.is_integration" class="form-input" placeholder="GitHub App Private Key" name="integration_key" required [(ngModel)]="token.integration_key" rows=8></textarea>
+                  <input *ngIf="!token.is_integration" class="form-input" type="text" placeholder="Access Token" name="token" required [(ngModel)]="token.token">
                 </div>
                 <div class="form-field">
                   <button type="submit" name="add-token" class="button green float-right" [disabled]="!tokenForm.form.valid">Add Token</button>

--- a/src/app/components/app-user/app-user.component.ts
+++ b/src/app/components/app-user/app-user.component.ts
@@ -9,6 +9,9 @@ import { switchMap, delay } from 'rxjs/operators';
 export interface IAccessToken {
   token: string;
   description: string;
+  is_integration: boolean;
+  integration_key: string;
+  integration_id: number;
   users_id: number;
 }
 
@@ -53,7 +56,7 @@ export class AppUserComponent implements OnInit {
   ngOnInit() {
     this.tab = 'profile';
     this.loggedUser = this.auth.getData();
-    this.token = { token: '', description: '', users_id: this.route.snapshot.params.id };
+    this.token = { token: '', description: '', is_integration: false, integration_key: '', integration_id: null, users_id: this.route.snapshot.params.id };
 
     this.fetchUser();
   }

--- a/tests/e2e/tests/010-GitHub/020-PushEvent/020.ts
+++ b/tests/e2e/tests/010-GitHub/020-PushEvent/020.ts
@@ -1,0 +1,17 @@
+import { request, header } from '../../../webhooks/github/EnterprisePushEvent';
+import { sendGitHubRequest } from '../../../utils/utils';
+import { stopBuild, delay } from '../../../utils/utils';
+
+export default function() {
+  return Promise.resolve()
+    .then(() => sendGitHubRequest(request, header))
+    .then(resp => {
+      if (resp.msg === 'ok') {
+        return delay(3000)
+          .then(() => stopBuild(resp.data.buildId));
+      } else {
+        Promise.reject(resp);
+      }
+    })
+    .catch(err => Promise.reject(err));
+}

--- a/tests/e2e/tests/060-repositories/030-check-api-url.ts
+++ b/tests/e2e/tests/060-repositories/030-check-api-url.ts
@@ -1,0 +1,41 @@
+import * as request from 'request';
+
+export default function() {
+  return Promise.resolve()
+    .then(() => {
+      return new Promise((resolve, reject) => {
+        let options = {
+          url: 'http://localhost:6500/api/repositories/id/1/1',
+          method: 'GET',
+          json: { test: 1 }
+        };
+
+        request(options, (err, response, body) => {
+          if (err) {
+            Promise.reject(err);
+          } else {
+            if (response.statusCode === 200) {
+              const repo = body;
+              if (repo.data && repo.data.api_url) {
+                if (repo.data.api_url === 'https://api.github.com') {
+                  resolve(repo);
+                } else {
+                  reject(repo.data);
+                }
+              } else {
+                reject({
+                  statusCode: response.statusCode,
+                  response: body
+                });
+              }
+            } else {
+              reject({
+                statusCode: response.statusCode,
+                response: body
+              });
+            }
+          }
+        });
+      });
+    });
+}

--- a/tests/e2e/webhooks/github/EnterprisePushEvent.ts
+++ b/tests/e2e/webhooks/github/EnterprisePushEvent.ts
@@ -1,0 +1,377 @@
+export let request = {
+  'ref': 'refs/heads/master',
+  'before': '494f47baeda0f20be99ceca28973a5b4e2639fac',
+  'after': '8e1c6452d41d7a45d0b16d5f711befdbbe2c0320',
+  'created': false,
+  'deleted': false,
+  'forced': false,
+  'base_ref': null,
+  'compare': 'https://github.com/jkuri/d3-bundle/compare/494f47baeda0...8e1c6452d41d',
+  'commits': [
+    {
+      'id': '8e1c6452d41d7a45d0b16d5f711befdbbe2c0320',
+      'tree_id': 'b26adb425bcdc41d853a4a99d666f7e5922fc412',
+      'distinct': true,
+      'message': 'chore(abstruse.yml): make proper config',
+      'timestamp': '2017-09-17T23:57:39+02:00',
+      'url': 'https://github.com/jkuri/d3-bundle/commit/8e1c6452d41d7a45d0b16d5f711befdbbe2c0320',
+      'author': {
+        'name': 'Jan Kuri',
+        'email': 'jkuri88@gmail.com',
+        'username': 'jkuri'
+      },
+      'committer': {
+        'name': 'Jan Kuri',
+        'email': 'jkuri88@gmail.com',
+        'username': 'jkuri'
+      },
+      'added': [
+
+      ],
+      'removed': [
+
+      ],
+      'modified': [
+        '.abstruse.yml'
+      ]
+    }
+  ],
+  'head_commit': {
+    'id': '8e1c6452d41d7a45d0b16d5f711befdbbe2c0320',
+    'tree_id': 'b26adb425bcdc41d853a4a99d666f7e5922fc412',
+    'distinct': true,
+    'message': 'chore(abstruse.yml): make proper config',
+    'timestamp': '2017-09-17T23:57:39+02:00',
+    'url': 'https://github.com/jkuri/d3-bundle/commit/8e1c6452d41d7a45d0b16d5f711befdbbe2c0320',
+    'author': {
+      'name': 'Jan Kuri',
+      'email': 'jkuri88@gmail.com',
+      'username': 'jkuri'
+    },
+    'committer': {
+      'name': 'Jan Kuri',
+      'email': 'jkuri88@gmail.com',
+      'username': 'jkuri'
+    },
+    'added': [
+
+    ],
+    'removed': [
+
+    ],
+    'modified': [
+      '.abstruse.yml'
+    ]
+  },
+  'repository': {
+    'id': 71424198,
+    'name': 'd3-bundle',
+    'full_name': 'jkuri/d3-bundle',
+    'owner': {
+      'name': 'jkuri',
+      'email': 'jkuri88@gmail.com',
+      'login': 'jkuri',
+      'id': 1796022,
+      'avatar_url': 'https://avatars1.githubusercontent.com/u/1796022?v=4',
+      'gravatar_id': '',
+      'url': 'https://github.enterprise.com/api/v3/users/jkuri',
+      'html_url': 'https://github.com/jkuri',
+      'followers_url': 'https://github.enterprise.com/api/v3/users/jkuri/followers',
+      'following_url': 'https://github.enterprise.com/api/v3/users/jkuri/following{/other_user}',
+      'gists_url': 'https://github.enterprise.com/api/v3/users/jkuri/gists{/gist_id}',
+      'starred_url': 'https://github.enterprise.com/api/v3/users/jkuri/starred{/owner}{/repo}',
+      'subscriptions_url': 'https://github.enterprise.com/api/v3/users/jkuri/subscriptions',
+      'organizations_url': 'https://github.enterprise.com/api/v3/users/jkuri/orgs',
+      'repos_url': 'https://github.enterprise.com/api/v3/users/jkuri/repos',
+      'events_url': 'https://github.enterprise.com/api/v3/users/jkuri/events{/privacy}',
+      'received_events_url': 'https://github.enterprise.com/api/v3/users/jkuri/received_events',
+      'type': 'User',
+      'site_admin': false
+    },
+    'private': false,
+    'html_url': 'https://github.com/jkuri/d3-bundle',
+    'description': null,
+    'fork': false,
+    'url': 'https://github.com/jkuri/d3-bundle',
+    'forks_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/forks',
+    'keys_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/keys{/key_id}',
+    'collaborators_url':
+      'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/collaborators{/collaborator}',
+    'teams_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/teams',
+    'hooks_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/hooks',
+    'issue_events_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/issues/events{/number}',
+    'events_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/events',
+    'assignees_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/assignees{/user}',
+    'branches_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/branches{/branch}',
+    'tags_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/tags',
+    'blobs_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/git/blobs{/sha}',
+    'git_tags_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/git/tags{/sha}',
+    'git_refs_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/git/refs{/sha}',
+    'trees_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/git/trees{/sha}',
+    'statuses_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/statuses/{sha}',
+    'languages_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/languages',
+    'stargazers_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/stargazers',
+    'contributors_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/contributors',
+    'subscribers_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/subscribers',
+    'subscription_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/subscription',
+    'commits_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/commits{/sha}',
+    'git_commits_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/git/commits{/sha}',
+    'comments_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/comments{/number}',
+    'issue_comment_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/issues/comments{/number}',
+    'contents_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/contents/{+path}',
+    'compare_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/compare/{base}...{head}',
+    'merges_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/merges',
+    'archive_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/{archive_format}{/ref}',
+    'downloads_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/downloads',
+    'issues_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/issues{/number}',
+    'pulls_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/pulls{/number}',
+    'milestones_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/milestones{/number}',
+    'notifications_url':
+      'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/notifications{?since,all,participating}',
+    'labels_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/labels{/name}',
+    'releases_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/releases{/id}',
+    'deployments_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/deployments',
+    'created_at': 1476936345,
+    'updated_at': '2016-10-20T04:06:39Z',
+    'pushed_at': 1505685467,
+    'git_url': 'git://github.com/jkuri/d3-bundle.git',
+    'ssh_url': 'git@github.com:jkuri/d3-bundle.git',
+    'clone_url': 'https://github.com/jkuri/d3-bundle.git',
+    'svn_url': 'https://github.com/jkuri/d3-bundle',
+    'homepage': null,
+    'size': 34612,
+    'stargazers_count': 0,
+    'watchers_count': 0,
+    'language': 'JavaScript',
+    'has_issues': true,
+    'has_projects': true,
+    'has_downloads': true,
+    'has_wiki': true,
+    'has_pages': false,
+    'forks_count': 1,
+    'mirror_url': null,
+    'open_issues_count': 0,
+    'forks': 1,
+    'open_issues': 0,
+    'watchers': 0,
+    'default_branch': 'master',
+    'stargazers': 0,
+    'master_branch': 'master'
+  },
+  'pusher': {
+    'name': 'jkuri',
+    'email': 'jkuri88@gmail.com'
+  },
+  'sender': {
+    'login': 'jkuri',
+    'id': 1796022,
+    'avatar_url': 'https://avatars1.githubusercontent.com/u/1796022?v=4',
+    'gravatar_id': '',
+    'url': 'https://github.enterprise.com/api/v3/users/jkuri',
+    'html_url': 'https://github.com/jkuri',
+    'followers_url': 'https://github.enterprise.com/api/v3/users/jkuri/followers',
+    'following_url': 'https://github.enterprise.com/api/v3/users/jkuri/following{/other_user}',
+    'gists_url': 'https://github.enterprise.com/api/v3/users/jkuri/gists{/gist_id}',
+    'starred_url': 'https://github.enterprise.com/api/v3/users/jkuri/starred{/owner}{/repo}',
+    'subscriptions_url': 'https://github.enterprise.com/api/v3/users/jkuri/subscriptions',
+    'organizations_url': 'https://github.enterprise.com/api/v3/users/jkuri/orgs',
+    'repos_url': 'https://github.enterprise.com/api/v3/users/jkuri/repos',
+    'events_url': 'https://github.enterprise.com/api/v3/users/jkuri/events{/privacy}',
+    'received_events_url': 'https://github.enterprise.com/api/v3/users/jkuri/received_events',
+    'type': 'User',
+    'site_admin': false
+  }
+};
+
+export let header = {
+  'content-type': 'application/json',
+  'X-GitHub-Event': 'push',
+  'X-Hub-Signature': 'sha1=b7c49c4f28d64c153ae1ab7f7a8627a1f66a9e55',
+  'X-GitHub-Delivery': '61109660-71f6-11e7-9b49-619c5e386bdf'
+};
+
+
+export let requestD3 = {
+  'ref': 'refs/heads/master',
+  'before': '494f47baeda0f20be99ceca28973a5b4e2639fac',
+  'after': '8e1c6452d41d7a45d0b16d5f711befdbbe2c0320',
+  'created': false,
+  'deleted': false,
+  'forced': false,
+  'base_ref': null,
+  'compare': 'https://github.com/jkuri/d3-bundle/compare/494f47baeda0...8e1c6452d41d',
+  'commits': [
+    {
+      'id': '8e1c6452d41d7a45d0b16d5f711befdbbe2c0320',
+      'tree_id': 'b26adb425bcdc41d853a4a99d666f7e5922fc412',
+      'distinct': true,
+      'message': 'chore(abstruse.yml): make proper config',
+      'timestamp': '2017-09-17T23:57:39+02:00',
+      'url': 'https://github.com/jkuri/d3-bundle/commit/8e1c6452d41d7a45d0b16d5f711befdbbe2c0320',
+      'author': {
+        'name': 'Jan Kuri',
+        'email': 'jkuri88@gmail.com',
+        'username': 'jkuri'
+      },
+      'committer': {
+        'name': 'Jan Kuri',
+        'email': 'jkuri88@gmail.com',
+        'username': 'jkuri'
+      },
+      'added': [
+
+      ],
+      'removed': [
+
+      ],
+      'modified': [
+        '.abstruse.yml'
+      ]
+    }
+  ],
+  'head_commit': {
+    'id': '8e1c6452d41d7a45d0b16d5f711befdbbe2c0320',
+    'tree_id': 'b26adb425bcdc41d853a4a99d666f7e5922fc412',
+    'distinct': true,
+    'message': 'chore(abstruse.yml): make proper config',
+    'timestamp': '2017-09-17T23:57:39+02:00',
+    'url': 'https://github.com/jkuri/d3-bundle/commit/8e1c6452d41d7a45d0b16d5f711befdbbe2c0320',
+    'author': {
+      'name': 'Jan Kuri',
+      'email': 'jkuri88@gmail.com',
+      'username': 'jkuri'
+    },
+    'committer': {
+      'name': 'Jan Kuri',
+      'email': 'jkuri88@gmail.com',
+      'username': 'jkuri'
+    },
+    'added': [
+
+    ],
+    'removed': [
+
+    ],
+    'modified': [
+      '.abstruse.yml'
+    ]
+  },
+  'repository': {
+    'id': 71424198,
+    'name': 'd3-bundle',
+    'full_name': 'jkuri/d3-bundle',
+    'owner': {
+      'name': 'jkuri',
+      'email': 'jkuri88@gmail.com',
+      'login': 'jkuri',
+      'id': 1796022,
+      'avatar_url': 'https://avatars1.githubusercontent.com/u/1796022?v=4',
+      'gravatar_id': '',
+      'url': 'https://github.enterprise.com/api/v3/users/jkuri',
+      'html_url': 'https://github.com/jkuri',
+      'followers_url': 'https://github.enterprise.com/api/v3/users/jkuri/followers',
+      'following_url': 'https://github.enterprise.com/api/v3/users/jkuri/following{/other_user}',
+      'gists_url': 'https://github.enterprise.com/api/v3/users/jkuri/gists{/gist_id}',
+      'starred_url': 'https://github.enterprise.com/api/v3/users/jkuri/starred{/owner}{/repo}',
+      'subscriptions_url': 'https://github.enterprise.com/api/v3/users/jkuri/subscriptions',
+      'organizations_url': 'https://github.enterprise.com/api/v3/users/jkuri/orgs',
+      'repos_url': 'https://github.enterprise.com/api/v3/users/jkuri/repos',
+      'events_url': 'https://github.enterprise.com/api/v3/users/jkuri/events{/privacy}',
+      'received_events_url': 'https://github.enterprise.com/api/v3/users/jkuri/received_events',
+      'type': 'User',
+      'site_admin': false
+    },
+    'private': false,
+    'html_url': 'https://github.com/jkuri/d3-bundle',
+    'description': null,
+    'fork': false,
+    'url': 'https://github.com/jkuri/d3-bundle',
+    'forks_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/forks',
+    'keys_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/keys{/key_id}',
+    'collaborators_url':
+      'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/collaborators{/collaborator}',
+    'teams_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/teams',
+    'hooks_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/hooks',
+    'issue_events_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/issues/events{/number}',
+    'events_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/events',
+    'assignees_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/assignees{/user}',
+    'branches_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/branches{/branch}',
+    'tags_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/tags',
+    'blobs_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/git/blobs{/sha}',
+    'git_tags_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/git/tags{/sha}',
+    'git_refs_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/git/refs{/sha}',
+    'trees_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/git/trees{/sha}',
+    'statuses_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/statuses/{sha}',
+    'languages_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/languages',
+    'stargazers_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/stargazers',
+    'contributors_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/contributors',
+    'subscribers_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/subscribers',
+    'subscription_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/subscription',
+    'commits_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/commits{/sha}',
+    'git_commits_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/git/commits{/sha}',
+    'comments_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/comments{/number}',
+    'issue_comment_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/issues/comments{/number}',
+    'contents_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/contents/{+path}',
+    'compare_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/compare/{base}...{head}',
+    'merges_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/merges',
+    'archive_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/{archive_format}{/ref}',
+    'downloads_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/downloads',
+    'issues_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/issues{/number}',
+    'pulls_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/pulls{/number}',
+    'milestones_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/milestones{/number}',
+    'notifications_url':
+      'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/notifications{?since,all,participating}',
+    'labels_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/labels{/name}',
+    'releases_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/releases{/id}',
+    'deployments_url': 'https://github.enterprise.com/api/v3/repos/jkuri/d3-bundle/deployments',
+    'created_at': 1476936345,
+    'updated_at': '2016-10-20T04:06:39Z',
+    'pushed_at': 1505685467,
+    'git_url': 'git://github.com/jkuri/d3-bundle.git',
+    'ssh_url': 'git@github.com:jkuri/d3-bundle.git',
+    'clone_url': 'https://github.com/jkuri/d3-bundle.git',
+    'svn_url': 'https://github.com/jkuri/d3-bundle',
+    'homepage': null,
+    'size': 34612,
+    'stargazers_count': 0,
+    'watchers_count': 0,
+    'language': 'JavaScript',
+    'has_issues': true,
+    'has_projects': true,
+    'has_downloads': true,
+    'has_wiki': true,
+    'has_pages': false,
+    'forks_count': 1,
+    'mirror_url': null,
+    'open_issues_count': 0,
+    'forks': 1,
+    'open_issues': 0,
+    'watchers': 0,
+    'default_branch': 'master',
+    'stargazers': 0,
+    'master_branch': 'master'
+  },
+  'pusher': {
+    'name': 'jkuri',
+    'email': 'jkuri88@gmail.com'
+  },
+  'sender': {
+    'login': 'jkuri',
+    'id': 1796022,
+    'avatar_url': 'https://avatars1.githubusercontent.com/u/1796022?v=4',
+    'gravatar_id': '',
+    'url': 'https://github.enterprise.com/api/v3/users/jkuri',
+    'html_url': 'https://github.com/jkuri',
+    'followers_url': 'https://github.enterprise.com/api/v3/users/jkuri/followers',
+    'following_url': 'https://github.enterprise.com/api/v3/users/jkuri/following{/other_user}',
+    'gists_url': 'https://github.enterprise.com/api/v3/users/jkuri/gists{/gist_id}',
+    'starred_url': 'https://github.enterprise.com/api/v3/users/jkuri/starred{/owner}{/repo}',
+    'subscriptions_url': 'https://github.enterprise.com/api/v3/users/jkuri/subscriptions',
+    'organizations_url': 'https://github.enterprise.com/api/v3/users/jkuri/orgs',
+    'repos_url': 'https://github.enterprise.com/api/v3/users/jkuri/repos',
+    'events_url': 'https://github.enterprise.com/api/v3/users/jkuri/events{/privacy}',
+    'received_events_url': 'https://github.enterprise.com/api/v3/users/jkuri/received_events',
+    'type': 'User',
+    'site_admin': false
+  }
+};

--- a/tests/unit/060_api-routes.spec.ts
+++ b/tests/unit/060_api-routes.spec.ts
@@ -85,6 +85,11 @@ describe('Api Server Routes Unit Tests', () => {
         expect(repo['data']['full_name']).to.deep.equal('jkuri/d3-bundle');
       });
     });
+    it(`get repository should not return access token data`, () => {
+      return sendGetRequest({}, 'api/repositories/id/2/1').then(repo => {
+        expect(repo['data']).to.not.include('access_token');
+      });
+    });
 
     it(`get repository should not include access token`, () => {
       return sendGetRequest({}, 'api/repositories/id/2/1').then((repo: any) => {

--- a/tests/unit/060_api-routes.spec.ts
+++ b/tests/unit/060_api-routes.spec.ts
@@ -85,9 +85,10 @@ describe('Api Server Routes Unit Tests', () => {
         expect(repo['data']['full_name']).to.deep.equal('jkuri/d3-bundle');
       });
     });
-    it(`get repository should not return access token data`, () => {
-      return sendGetRequest({}, 'api/repositories/id/2/1').then(repo => {
-        expect(repo['data']).to.not.include('access_token');
+
+    it(`get repository should not include access token`, () => {
+      return sendGetRequest({}, 'api/repositories/id/2/1').then((repo: any) => {
+        expect(repo.data).to.not.have.property('access_token');
       });
     });
 


### PR DESCRIPTION
- Support GitHub enterprise api endpoints
- Add tests to verify GitHub urls are parsed correctly
- Change access token form to support integrations
  - Allow GitHub app to be toggled
  - Allow private key to be uploaded
  - Allow Installation and Integration id to be set
- Change service worker to re-authenticate expired tokens
- Change git process to log to screen
- Add documentation for app integration
- Use correct repository url (as specified in settings) when setting commit statuses

Closes #351 