### PR TITLE
Fix UTC minutes issue 

### DIFF
--- a/src/app/pipes/to-time.pipe.ts
+++ b/src/app/pipes/to-time.pipe.ts
@@ -1,6 +1,19 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { format } from 'date-fns';
 
+const getUTCDate = (dateString = Date.now()) => {
+  const date = new Date(dateString);
+
+  return new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds(),
+  );
+};
+
 @Pipe({ name: 'toTime'})
 export class ToTimePipe implements PipeTransform  {
   transform(value) {
@@ -9,10 +22,12 @@ export class ToTimePipe implements PipeTransform  {
     } else {
       let time = new Date(value);
       let hours = time.getUTCHours();
+      let minutesAndSeconds = format(getUTCDate(value), 'mm:ss');
+
       if (hours > 0) {
-        return `${hours}:${format(value, 'mm:ss')}`;
+        return `${hours}:${minutesAndSeconds}`;
       } else {
-        return format(value, 'mm:ss');
+        return minutesAndSeconds;
       }
     }
   }


### PR DESCRIPTION
When you run abstruce from timezone other than UTC, the minutes in build time is displayed with offset added.

Eg: If you run from India (timezone +5:30), the build always starts from 30 min in the browser, this looks like issue with `format` function of `date-fns`(couldn't find a way to configure UTC), The build finished in 9:54 minutes, but time shown is 39:54 minutes.

<img width="105" alt="screen shot 2018-08-27 at 11 31 29 am" src="https://user-images.githubusercontent.com/4010960/44643203-497be600-a9ed-11e8-8cd9-fa84b21b73de.png">