### PR TITLE
docs: provide tips on non-amd64 architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 # Stage 1 image
+
+# FROM arm64v8/node:alpine as base # aarch64
 FROM mhart/alpine-node:10 as base
 
 ENV DOCKER_VERSION=18.03.1-ce
 
+#ENV ARCH=aarch64 # aarch64
+ENV ARCH=x86_64
+
 RUN apk --no-cache add openssl \
-    && wget https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz -O /tmp/docker.tgz \
+    && wget https://download.docker.com/linux/static/stable/$ARCH/docker-$DOCKER_VERSION.tgz -O /tmp/docker.tgz \
     && mkdir /tmp/docker && tar xzf /tmp/docker.tgz -C /tmp \
     && ln -s /tmp/docker/docker /usr/bin/docker && chmod 755 /usr/bin/docker && rm -rf /tmp/docker.tgz \
     && apk del openssl

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -3,6 +3,7 @@
 ### Table of Contents
 
 * [Docker Image](#docker-image)
+* [Notice on non amd64](#non-amd64)
 * [Install From Npm](#install-from-npm)
 * [Run From Source](#run-from-source)
 * [Run Test Builds](#run-test-builds)
@@ -38,6 +39,12 @@ this while using `abstruse` docker image.
 
 Run your favorite `Chrome` browser and navigate to `http://localhost:6500`. You should see `abstruse` setup page which will guide you
 throught the initial setup.
+
+### Non amd64
+
+Abstruse is intended to work on amd64 architectures, however, if you're willing to install abstruse on a rasp, odroid or any other kind of computer you have to tweak Dockerfile to target other architectures such as arm64 (aarch64) and so forth.
+
+You can check this notes as a comments on https://github.com/bleenco/abstruse/blob/master/Dockerfile
 
 ### Install From npm
 


### PR DESCRIPTION
Thanks for this nice OSS

https://github.com/bleenco/abstruse/issues/413 related, I don't know if you're agree but this project is growing popular and, because is very portable and small (relative to other ci tools) many people will try to install into other systems

 