### PR TITLE
Update config file location

### DIFF
--- a/docs/INTEGRATING_GIT_PROVIDERS.md
+++ b/docs/INTEGRATING_GIT_PROVIDERS.md
@@ -6,7 +6,7 @@
 
 #### 1. Configuring secret token
 
-Abstruse configuration file is located in **~/.abstruse/config.json**.
+Abstruse configuration file is located in **~/.abstruse/abstruse-config/config.json**.
 
 The integration of GitHub webhooks and Abstruse is done using `secret` token. The default `secret` is set to **thisIsSecret**.
 


### PR DESCRIPTION
Config file is located here: ~/.abstruse/abstruse-config/config.json. Updated documentation to reflect the correct file location.