### PR TITLE
Fix a build bug in pb/api.proto

### DIFF
--- a/pb/api.proto
+++ b/pb/api.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package api;
-option go_package = ".;api";
+option go_package = "./;api";
 
 import "google/protobuf/empty.proto";
 


### PR DESCRIPTION
In recent versions of protoc, import paths are required to have
at least one `/`.
This path fixes this build error.