### PR TITLE
docs(readme): fix link to the license

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ $ make dev_worker
 
 ## License
 
-See the [license](https://github.com/irmana/abstruse/blob/master/LICENSE).
+See the [license](https://github.com/bleenco/abstruse/blob/master/LICENSE).


### PR DESCRIPTION
It redirected to the `@irmana`'s fork license instead of `@bleenco`'s.