### PR TITLE
fix(core): build failed to start

### DIFF
--- a/server/core/job.go
+++ b/server/core/job.go
@@ -8,7 +8,7 @@ type (
 		ID        uint       `gorm:"primary_key;auto_increment;not null" json:"id"`
 		Commands  string     `sql:"type:text" json:"commands"`
 		Image     string     `json:"image"`
-		Env       string     `json:"env"`
+		Env       string     `sql:"type:text" json:"env"`
 		StartTime *time.Time `json:"startTime"`
 		EndTime   *time.Time `json:"endTime"`
 		Status    string     `gorm:"not null;size:20;default:'queued'" json:"status"` // queued | running | passing | failing


### PR DESCRIPTION
When a new build was created, `env` in `jobs` table was `varchar(255)`, which was able to accept only 255 characters.

I can confirm that this fixed the problem after manually changing `varchar(255)` into `text` in phpmyadmin