### PR TITLE
build(Docker): use alpine for docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN go get github.com/jkuri/statik github.com/golang/protobuf/protoc-gen-go gith
 RUN make protoc && make statik && make wire && make server
 
 # stage 3 image
-FROM scratch
+FROM alpine:latest
 
 LABEL maintainer="Jan Kuri <jkuri88@gmail.com>" \
   org.label-schema.schema-version="1.0" \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -15,7 +15,7 @@ RUN go get github.com/jkuri/statik github.com/golang/protobuf/protoc-gen-go gith
 RUN make protoc && make wire && make worker
 
 # stage 2 image
-FROM scratch
+FROM alpine:latest
 
 LABEL maintainer="Jan Kuri <jkuri88@gmail.com>" \
   org.label-schema.schema-version="1.0" \


### PR DESCRIPTION
Since we are using `CGO_ENABLED=1` in builds to include SQLite support, this doesn't work with `scratch` as base image, U updated to `alpine:latest`.