### PR TITLE
fix(Makefile): put protoc before wire

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CGO_ENABLED=1
 
 all: build
 
-build: build_ui statik wire protoc server worker
+build: build_ui statik protoc wire server worker
 
 release:
 	@CGO_ENABLED=${CGO_ENABLED} gox -osarch="darwin/amd64 linux/amd64 linux/arm linux/386" -ldflags "-X ${ABSTRUSE_VERSION_PATH}.GitCommit=${GIT_COMMIT} -X ${ABSTRUSE_VERSION_PATH}.UIVersion=${ABSTRUSE_UI_VERSION} -X ${ABSTRUSE_VERSION_PATH}.BuildDate=${BUILD_DATE}" -output build/{{.Dir}}_{{.OS}}_{{.Arch}} ./cmd/abstruse-server


### PR DESCRIPTION
Wire fails with following output on clean build after clone:

```plain
wire: go [list -e -json -compiled=true -test=false -export=false -deps=true -find=false -tags=wireinject -- ./server/cmd/... ./worker/cmd/...]: exit status 1: go build github.com/bleenco/abstruse/pb: no Go files in
```
Doing `make protoc` first solve the issue.