### PR TITLE
fix(job): log was too long (closes #556)

### DIFF
--- a/server/core/job.go
+++ b/server/core/job.go
@@ -13,7 +13,7 @@ type (
 		StartTime *time.Time `json:"startTime"`
 		EndTime   *time.Time `json:"endTime"`
 		Status    string     `gorm:"not null;size:20;default:'queued'" json:"status"` // queued | running | passing | failing
-		Log       string     `gorm:"size:16777216" json:"-"`
+		Log       string     `gorm:"size:16777216" json:"-" sql:"type:longtext"`
 		Stage     string     `json:"stage"`
 		Cache     string     `json:"cache"`
 		Build     *Build     `gorm:"preload:false" json:"build,omitempty"`

--- a/server/store/job/job.go
+++ b/server/store/job/job.go
@@ -52,6 +52,9 @@ func (s jobStore) Create(job *core.Job) error {
 func (s jobStore) Update(job *core.Job) error {
 	log := []byte(job.Log)
 
+	if len(job.Log) > 16777215 {
+		job.Log = job.Log[0:16777215]
+	}
 	err := s.db.Model(job).Updates(map[string]interface{}{
 		"status":     job.Status,
 		"start_time": job.StartTime,


### PR DESCRIPTION
Fix issue #556, caused by the log being too long to fit in the table

I didn't test it (yet), but it should fix the issue.