### PR TITLE
fix(cache): Fix Null pointer exception if cache dir not exists

### DIFF
--- a/worker/cache/cache.go
+++ b/worker/cache/cache.go
@@ -45,12 +45,12 @@ func createArchive(folders []string, outPath string) error {
 	for _, folder := range folders {
 		folder = filepath.Join(filepath.Dir(outPath), folder)
 		if err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
-			if info.IsDir() {
-				return nil
-			}
-
 			if err != nil {
 				return err
+			}
+
+			if info.IsDir() {
+				return nil
 			}
 
 			link := ""


### PR DESCRIPTION
If user try to save some data from unmounted dirs (like  docker "root" or /proc, /dev, etc), we got Nullpointerexception at "info.IsDir()" because info is nil

example config
```
cache:
  - /proc
```

```
==> Saving cache... 
==> rpc error: code = Internal desc = runtime error: invalid memory address or nil pointer dereference
```