### PR TITLE
feat(docker): Add support for multi-platform build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/moby/term v0.0.0-20210610120745-9d4ed1856297 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/narqo/go-badge v0.0.0-20190124110329-d9415e4e1e9f
+	github.com/opencontainers/image-spec v1.0.1
 	github.com/shirou/gopsutil v3.20.10+incompatible
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.0

--- a/pb/api.proto
+++ b/pb/api.proto
@@ -69,6 +69,7 @@ message Job {
   string sshPrivateKey = 21;
   bool sshClone = 22;
   string branch = 23;
+  string platform = 24;
 }
 
 message Command {

--- a/server/core/job.go
+++ b/server/core/job.go
@@ -10,6 +10,7 @@ type (
 		Image     string     `json:"image"`
 		Env       string     `json:"env"`
 		Mount     string     `json:"mount"`
+		Platform  string     `json:"platform"`
 		StartTime *time.Time `json:"startTime"`
 		EndTime   *time.Time `json:"endTime"`
 		Status    string     `gorm:"not null;size:20;default:'queued'" json:"status"` // queued | running | passing | failing

--- a/server/core/repo.go
+++ b/server/core/repo.go
@@ -35,6 +35,7 @@ type (
 		Provider      Provider      `json:"-"`
 		EnvVariables  []EnvVariable `json:"-"`
 		Mounts        []*Mount      `json:"mounts"`
+		Platforms     string        `json:"platforms"`
 		Perms         Perms         `json:"perms"`
 		Timestamp
 	}

--- a/server/scheduler/scheduler.go
+++ b/server/scheduler/scheduler.go
@@ -333,6 +333,7 @@ func (s *scheduler) startJob(job *core.Job, worker *core.Worker) {
 		Mount:         strings.Split(job.Mount, ","),
 		SshPrivateKey: job.Build.Repository.SSHPrivateKey,
 		SshClone:      job.Build.Repository.UseSSH,
+		Platform:      job.Platform,
 	}
 
 	s.mu.Lock()

--- a/server/store/build/build.go
+++ b/server/store/build/build.go
@@ -318,31 +318,33 @@ func (s buildStore) TriggerBuild(opts core.TriggerBuildOpts) ([]*core.Job, error
 	}
 
 	var jobs []*core.Job
-	for _, j := range pjobs {
-		commands, err := protojson.Marshal(j.Commands)
-		if err != nil {
-			return nil, err
-		}
+	for platform := range strings.Split(repo.Platforms, ";") {
+		for _, j := range pjobs {
+			commands, err := protojson.Marshal(j.Commands)
+			if err != nil {
+				return nil, err
+			}
 
-		job := &core.Job{
-			Image:    j.Image,
-			Commands: string(commands),
-			Env:      strings.Join(j.Env, " "),
-			Mount:    strings.Join(mnts, ","),
-			Stage:    j.Stage,
-			BuildID:  build.ID,
-			Cache:    strings.Join(j.Cache, ","),
-		}
-		if err := s.jobs.Create(job); err != nil {
-			return nil, err
-		}
-		job, err = s.jobs.Find(job.ID)
-		if err != nil {
-			return nil, err
-		}
+			job := &core.Job{
+				Image:    j.Image,
+				Commands: string(commands),
+				Env:      strings.Join(j.Env, " "),
+				Mount:    strings.Join(mnts, ","),
+				Stage:    j.Stage,
+				BuildID:  build.ID,
+				Cache:    strings.Join(j.Cache, ","),
+				Platform: strings.Split(repo.Platforms, ";")[platform],
+			}
+			if err := s.jobs.Create(job); err != nil {
+				return nil, err
+			}
+			job, err = s.jobs.Find(job.ID)
+			if err != nil {
+				return nil, err
+			}
 
-		jobs = append(jobs, job)
+			jobs = append(jobs, job)
+		}
 	}
-
 	return jobs, nil
 }

--- a/worker/app/server.go
+++ b/worker/app/server.go
@@ -233,8 +233,8 @@ func (s *Server) StartJob(job *pb.Job, stream pb.API_StartJobServer) error {
 	}
 	logch <- []byte(yellow("done\r\n"))
 
-	logch <- []byte(yellow(fmt.Sprintf("==> Pulling image %s... ", image)))
-	if err := docker.PullImage(image, s.config.Registry); err != nil {
+	logch <- []byte(yellow(fmt.Sprintf("==> Pulling image %s (%s)... ", image, job.Platform)))
+	if err := docker.PullImage(image, job.Platform, s.config.Registry); err != nil {
 		logch <- []byte(fmt.Sprintf("%s\r\n", err.Error()))
 	} else {
 		logch <- []byte(yellow("done\r\n"))

--- a/worker/docker/image.go
+++ b/worker/docker/image.go
@@ -84,14 +84,16 @@ func PushImage(tag string) (io.ReadCloser, error) {
 }
 
 // PullImage pulls image from the registry.
-func PullImage(image string, config *config.Registry) error {
+func PullImage(image string, platform string, config *config.Registry) error {
 	ctx := context.Background()
 	cli, err := client.NewClientWithOpts()
 	if err != nil {
 		panic(err)
 	}
 
-	opts := types.ImagePullOptions{}
+	opts := types.ImagePullOptions{
+		Platform: platform,
+	}
 
 	if cfg.Username != "" && cfg.Password != "" {
 		authConfig := types.AuthConfig{Username: cfg.Username, Password: cfg.Password}

--- a/worker/docker/platform.go
+++ b/worker/docker/platform.go
@@ -1,0 +1,29 @@
+package docker
+
+import (
+	"runtime"
+	"strings"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func getPlatform(platform string) v1.Platform {
+	s := strings.Split(platform, "/")
+	if len(s) == 2 {
+		return v1.Platform{
+			OS:           s[0],
+			Architecture: s[1],
+		}
+	}
+	if len(s) == 3 {
+		return v1.Platform{
+			OS:           s[0],
+			Architecture: s[1],
+			Variant:      s[2],
+		}
+	}
+	return v1.Platform{
+		OS:           runtime.GOOS,
+		Architecture: runtime.GOARCH,
+	}
+}


### PR DESCRIPTION
This pull request close #559

Since docker already support multiarch by using qemu, it would be cool to have abstruse support it also,

Commands required to setup:
```bash
(HOST)# apt install -y qemu binfmt-support qemu-user-static
(HOST)# docker run --rm --privileged multiarch/qemu-user-static:register
```

Currently there is no gui for setting platforms (and it is not likely that I'll do that.. I have no idea how frontend works), so in database you need to update `platforms` row with something like: `linux/amd64;linux/arm64`

After that trigger a build and you will see this:

| linux/arm64 | linux/amd64 |
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/20381330/132925533-600387b9-02d3-4a9c-a935-b5483cf57bc0.png) | ![image](https://user-images.githubusercontent.com/20381330/132925544-ef8e2d92-9b8f-421b-a5ed-23d1fc110c15.png) |
