### PR TITLE
feature(web): Show agent hostname instead agent address

### DIFF
--- a/web/abstruse/src/app/workers/shared/worker.model.ts
+++ b/web/abstruse/src/app/workers/shared/worker.model.ts
@@ -50,6 +50,10 @@ export class Worker {
     return `${curr} / ${max}`;
   }
 
+  get getHostnameOrAddress(): string {
+    return this.hostname || this.addr ;
+  }
+
   updateUsage(data: { cpu: number; mem: number; jobsMax: number; jobsRunning: number }): void {
     this.cpu[0].push({ value: data.cpu, date: new Date() });
     this.memory[0].push({ value: data.mem, date: new Date() });

--- a/web/abstruse/src/app/workers/worker-table-item/worker-table-item.component.html
+++ b/web/abstruse/src/app/workers/worker-table-item/worker-table-item.component.html
@@ -7,7 +7,7 @@
     </div>
     <div class="column is-2">
       <div class="table-data">
-        <span class="text-secondary justify-center">{{ worker.addr }}</span>
+        <span class="text-secondary justify-center">{{ worker.getHostnameOrAddress }}</span>
       </div>
     </div>
     <div class="column is-3">

--- a/web/abstruse/src/app/workers/workers/workers.component.html
+++ b/web/abstruse/src/app/workers/workers/workers.component.html
@@ -44,7 +44,7 @@
               <span class="table-header-title justify-center">ID</span>
             </div>
             <div class="column is-2">
-              <span class="table-header-title justify-center">Address</span>
+              <span class="table-header-title justify-center">Hostname</span>
             </div>
             <div class="column is-3">
               <span class="table-header-title pl20">OS</span>


### PR DESCRIPTION
We use ipv6 in our agents, and this address is not fully displayed in the allotted field.
I suggest using the agent's hostname if possible, and fallback to ip address otherwise.

![image](https://user-images.githubusercontent.com/28133561/158383118-98db90a0-f164-4ee2-ae08-9052ef4de77f.png)
