### PR TITLE
feat(worker): Add support for configuring docker host settings

### DIFF
--- a/worker/cmd/cmd.go
+++ b/worker/cmd/cmd.go
@@ -99,6 +99,10 @@ func init() {
 	rootCmd.PersistentFlags().Int("logger-max-size", 500, "maximum log file size (in MB)")
 	rootCmd.PersistentFlags().Int("logger-max-backups", 3, "maximum log file backups")
 	rootCmd.PersistentFlags().Int("logger-max-age", 3, "maximum log age")
+	rootCmd.PersistentFlags().StringSlice("docker-mounts", []string{}, "Global mount points, colon separated")
+	rootCmd.PersistentFlags().StringSlice("docker-devices", []string{}, "Device redirection, colon separated")
+	rootCmd.PersistentFlags().Bool("docker-privileged", false, "Run build container in privileged mode")
+	rootCmd.PersistentFlags().StringSlice("docker-addcaps", []string{}, "Add Linux capabilities")
 }
 
 func initDefaults() {
@@ -118,6 +122,10 @@ func initDefaults() {
 	viper.BindPFlag("logger.maxsize", rootCmd.PersistentFlags().Lookup("logger-max-size"))
 	viper.BindPFlag("logger.maxbackups", rootCmd.PersistentFlags().Lookup("logger-max-backups"))
 	viper.BindPFlag("logger.maxage", rootCmd.PersistentFlags().Lookup("logger-max-age"))
+	viper.BindPFlag("docker.mounts", rootCmd.PersistentFlags().Lookup("docker-mounts"))
+	viper.BindPFlag("docker.devices", rootCmd.PersistentFlags().Lookup("docker-devices"))
+	viper.BindPFlag("docker.privileged", rootCmd.PersistentFlags().Lookup("docker-privileged"))
+	viper.BindPFlag("docker.addcaps", rootCmd.PersistentFlags().Lookup("docker-addcaps"))
 }
 
 func newConfig() *config.Config {
@@ -185,7 +193,7 @@ func newConfig() *config.Config {
 		fatal(err)
 	}
 
-	docker.Init(cfg.Registry)
+	docker.Init(cfg)
 
 	return cfg
 }

--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -11,6 +11,7 @@ type (
 		Auth      *Auth      `json:"auth"`
 		Registry  *Registry  `json:"registry"`
 		Logger    *Logger    `json:"logger"`
+		Docker    *Docker    `json:"docker"`
 	}
 
 	// Server configuration.
@@ -54,5 +55,13 @@ type (
 		MaxAge     int    `json:"maxage"`
 		Level      string `json:"level"`
 		Stdout     bool   `json:"stdout"`
+	}
+
+	// Docker Additional host configuration.
+	Docker struct {
+		Mounts     []string `json:"mounts"`
+		Devices    []string `json:"devices"`
+		Privileged bool     `json:"privileged"`
+		AddCaps    []string `json:"addcaps"`
 	}
 )

--- a/worker/docker/image.go
+++ b/worker/docker/image.go
@@ -76,7 +76,7 @@ func PushImage(tag string) (io.ReadCloser, error) {
 	}
 	tag = prependTag(tag)
 
-	authConfig := types.AuthConfig{Username: cfg.Username, Password: cfg.Password}
+	authConfig := types.AuthConfig{Username: cfg.registry.Username, Password: cfg.registry.Password}
 	authJSON, _ := json.Marshal(authConfig)
 	auth := base64.URLEncoding.EncodeToString(authJSON)
 
@@ -93,8 +93,8 @@ func PullImage(image string, config *config.Registry) error {
 
 	opts := types.ImagePullOptions{}
 
-	if cfg.Username != "" && cfg.Password != "" {
-		authConfig := types.AuthConfig{Username: cfg.Username, Password: cfg.Password}
+	if cfg.registry.Username != "" && cfg.registry.Password != "" {
+		authConfig := types.AuthConfig{Username: cfg.registry.Username, Password: cfg.registry.Password}
 		authJSON, _ := json.Marshal(authConfig)
 		opts.RegistryAuth = base64.URLEncoding.EncodeToString(authJSON)
 	}
@@ -148,8 +148,8 @@ func configureTags(tags []string) []string {
 }
 
 func prependTag(tag string) string {
-	if !strings.HasPrefix(tag, cfg.Addr) {
-		tag = path.Clean(path.Join(cfg.Addr, tag))
+	if !strings.HasPrefix(tag, cfg.registry.Addr) {
+		tag = path.Clean(path.Join(cfg.registry.Addr, tag))
 	}
 	return tag
 }

--- a/worker/docker/init.go
+++ b/worker/docker/init.go
@@ -3,10 +3,14 @@ package docker
 import "github.com/bleenco/abstruse/worker/config"
 
 var (
-	cfg *config.Registry
+	cfg struct {
+		registry *config.Registry
+		host     *config.Docker
+	}
 )
 
 // Init initializes global variables
-func Init(config *config.Registry) {
-	cfg = config
+func Init(config *config.Config) {
+	cfg.registry = config.Registry
+	cfg.host = config.Docker
 }


### PR DESCRIPTION
Reference to https://github.com/docker/for-linux/issues/321 currently where are no way to use FUSE fs in docker container. [Official manual](https://docs.docker.com/engine/reference/run/#logging-drivers---log-driver) (see one above) recommend to run container with `--cap-add` and `--device` options. 

This PR add support some new Docker host options in worker config:
* `--docker-addcaps` -- Values to bypass `docker run --cap-add=<value>`
*  `--docker-mounts` -- Global mount points. Very useful to prevent mounting docker.sock for each builds
* `--docker-devices` -- Device redirection. Useful to redirect `/dev/*` into container. Need to works with fuse fs
*  `--docker-privileged` -- Run build container in privileged mode. Bool, default `False`

All string options allow multiple choices. E.g.
```
abstruse-worker --docker-mounts "/var/log:/var/log" --docker-mounts "/tmp:/tmp"
```