### PR TITLE
Changes docker network size to valid for docker compose

### DIFF
--- a/configs/demo/default/docker-compose.yml
+++ b/configs/demo/default/docker-compose.yml
@@ -67,4 +67,4 @@ networks:
     driver: bridge
     ipam:
       config:
-        - subnet: 10.20.20.0/16
+        - subnet: 10.20.20.0/24

--- a/configs/testing/e2e/docker-compose.yml
+++ b/configs/testing/e2e/docker-compose.yml
@@ -92,4 +92,4 @@ networks:
     driver: bridge
     ipam:
       config:
-        - subnet: 10.20.20.0/16
+        - subnet: 10.20.20.0/24

--- a/configs/testing/e2e_postgres/docker-compose.yml
+++ b/configs/testing/e2e_postgres/docker-compose.yml
@@ -96,4 +96,4 @@ networks:
     driver: bridge
     ipam:
       config:
-        - subnet: 10.20.20.0/16
+        - subnet: 10.20.20.0/24


### PR DESCRIPTION
Docker compose plugin can't start using these configs because the network 10.20.20.0/16 is invalid and it expects either 10.20.0.0/16 or 10.20.20.0/24. Since we're using only up to five addresses and change only 4th octet, it's more viable to change the network to /24.

Relevant issue: https://github.com/bleenco/abstruse/issues/602